### PR TITLE
Update README.md with Raspbian specifics

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Make sure that SPI is enabled in `raspi-config`. The user executing the code mus
 #### Usage examples
 For some examples of usage, take a look at the integration tests.
 
+---
 
-
-# Notes on performance
+### Notes on performance
 
 #### VCOM value
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # IT8951
 
-This Python 3 module implements a driver for the IT8951 e-paper controller, via SPI.
-The driver was developed using the 6-inch e-Paper HAT from Waveshare. It hopefully will work for
-other (related) hardware too.
+This Python 3 module implements a driver for the IT8951 e-paper controller, via the SPI bus.
+The driver was developed using the 6-inch e-Paper HAT from Waveshare and has been confirmed to also work with the 7.8-inch model which uses the same controller HAT. It hopefully will work for other (related) hardware too.
 
 To install, clone the repository, enter the directory and run
 ```
@@ -10,13 +9,15 @@ pip install -r requirements.txt
 pip install ./
 ```
 
-Make sure that SPI is enabled in `raspi-config`.
+#### Raspbian specific information
+Make sure that SPI is enabled in `raspi-config`. The user executing the code must be a member of the groups "spi" and "gpio" to gain access to the required /dev resources without using sudo
 
----
-
+#### Usage examples
 For some examples of usage, take a look at the integration tests.
 
-### Notes on performance
+
+
+# Notes on performance
 
 #### VCOM value
 


### PR DESCRIPTION
Added information on the following topics
- Raspbian group membership requirements for access to /dev/spidev and /dev/gpio
- Noted working also with the 7.8-inch e-paper model that shares the same controller HAT

and some minor formatting to pre-existing text