### PR TITLE
Added support for display mirroring

### DIFF
--- a/IT8951/display.py
+++ b/IT8951/display.py
@@ -67,14 +67,15 @@ class AutoDisplay:
     def _set_rotate(self, rotate):
 
         methods = {
-            None   : None,
-            'CW'   : Image.ROTATE_270,
-            'CCW'  : Image.ROTATE_90,
-            'flip' : Image.ROTATE_180,
+            None     : None,
+            'CW'     : Image.ROTATE_270,
+            'CCW'    : Image.ROTATE_90,
+            'flip'   : Image.ROTATE_180,
+            'mirror' : Image.FLIP_LEFT_RIGHT,
         }
 
         if rotate not in methods:
-            raise ValueError("invalid value for 'rotate'---options are None, 'CW', 'CCW', and 'flip'")
+            raise ValueError("invalid value for 'rotate'---options are None, 'CW', 'CCW', 'flip', and 'mirror'")
 
         self._rotate_method = methods[rotate]
 

--- a/test/integration/test.py
+++ b/test/integration/test.py
@@ -10,7 +10,7 @@ def parse_args():
                    help='display using a Tkinter window instead of the '
                         'actual e-paper device (for testing without a '
                         'physical device)')
-    p.add_argument('-r', '--rotate', default=None, choices=['CW', 'CCW', 'flip'],
+    p.add_argument('-r', '--rotate', default=None, choices=['CW', 'CCW', 'flip', 'mirror'],
                    help='run the tests with the display rotated by the specified value')
     return p.parse_args()
 


### PR DESCRIPTION
I added an option to the rotation argument allowing for display mirroring to address an issue that seems to crop up on some of the displays (a 10.3" one, in my case). Running the test script with "-r mirror" will flip the display left-right.
Relevant issues: #40 #25 #37 