### PR TITLE
update display prev_frame on display clear

### DIFF
--- a/IT8951/display.py
+++ b/IT8951/display.py
@@ -149,6 +149,7 @@ class AutoDisplay:
         # set frame buffer to all white
         self.frame_buf.paste(0xFF, box=(0, 0, self.width, self.height))
         self.draw_full(DisplayModes.INIT)
+        self.prev_frame = self._get_frame_buf()
 
     @classmethod
     def _compute_diff_box(cls, a, b, round_to=2):


### PR DESCRIPTION
# What?
Update `AutoDisplay.prev_frame` in `AutoDisplay.clear`

# Why?
Currently, calling `draw_partial` after the screen has been cleared will produce incorrect result. 
ie: Because the image diff will be run against the last displayed frame, which has been cleared.

A workaround is to call `draw_full` after `clear` because it will ignore the current `prev_frame` and update it correctly, but it isn't feasible in my use case where I update different parts of the screen independently.